### PR TITLE
Renamed `force-cere-devnet`

### DIFF
--- a/cli/src/cli.rs
+++ b/cli/src/cli.rs
@@ -13,9 +13,9 @@ pub struct RunCmd {
 	#[clap(flatten)]
 	pub base: sc_cli::RunCmd,
 
-	/// Force using CereDev runtime.
-	#[clap(long = "force-cere-devnet")]
-	pub force_cere_devnet: bool,
+	/// Force using Cere Dev runtime.
+	#[clap(long = "force-cere-dev")]
+	pub force_cere_dev: bool,
 
 	/// Disable automatic hardware benchmarks.
 	///

--- a/cli/src/command.rs
+++ b/cli/src/command.rs
@@ -42,7 +42,7 @@ impl SubstrateCli for Cli {
 			path => {
 				let path = std::path::PathBuf::from(path);
 
-				if self.run.force_cere_devnet {
+				if self.run.force_cere_dev {
 					Box::new(cere_service::CereDevChainSpec::from_json_file(path)?)
 				} else {
 					Box::new(cere_service::CereChainSpec::from_json_file(path)?)


### PR DESCRIPTION
We have 2 runtimes: `cere` and `cere-dev`
To follow name conventions we should rename `force-cere-devnet` to `force-cere-dev`.